### PR TITLE
Add term 'known_hosts' to vocab

### DIFF
--- a/styles/Vocab/Stakater/accept.txt
+++ b/styles/Vocab/Stakater/accept.txt
@@ -106,6 +106,7 @@ JWT[s]?
 Katacoda
 Kiali
 Kibana
+known_hosts
 Konfigurator
 ksonnet
 Kube


### PR DESCRIPTION
This is needed for Tronador docs, where this ssh field is being mentioned